### PR TITLE
Fixing SignArtist plugin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       - |
         # MAIN
         apt-get update
-        apt-get install -y dos2unix rsync sudo vim nano
+        apt-get install -y dos2unix rsync sudo vim nano libgdiplus
         #grant access to video card for direct rendering (not used by rust ds)
         #function get_video_gid() {
         #  find /dev/dri -maxdepth 1 -type c | head -n1 | xargs stat -c %g


### PR DESCRIPTION
Install libgdiplus lib for using SignArtist plugin.