### PR TITLE
Attempt auto detection when rcon pass not available

### DIFF
--- a/admin/get-rcon-pass.sh
+++ b/admin/get-rcon-pass.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
 echo -n 'RCON password: '
-docker-compose exec -T lgsm cat rcon_pass
+docker-compose exec -T lgsm cat rcon_pass 2> /dev/null || (
+  # Could not find rcon random password file so falling back to auto detection.
+  docker-compose exec -T lgsm pgrep RustDedicated | \
+  xargs -n1 -I'{}' -- docker-compose exec -T lgsm cat '/proc/{}/cmdline' | \
+  tr '\0' '\n' | \
+  awk '$1 == "+rcon.password" { x="1"; next}; x == "1" {print $0; exit}'
+)
 
 echo '
 Visit one of the following web RCON clients:


### PR DESCRIPTION
Sometimes there's no randomly generated `rcon_pass` file.  In this case, attempt to inspecting the process runtime to retreive password arguments.