### PR TITLE
typo on utils.sh

### DIFF
--- a/utils/apply-settings.sh
+++ b/utils/apply-settings.sh
@@ -93,7 +93,7 @@ fi
 apply-setting "$lgsm_cfg" maxplayers "maxplayers=$maxplayers"
 
 # Custom Map Support
-function start-custom-map-server() (
+function start-custom-map-server() {
   cd /custom-maps/
   if ! pgrep -f SimpleHTTPServer > /dev/null; then
     if minimum python '3.2'; then
@@ -107,7 +107,7 @@ function start-custom-map-server() (
       exit 1
     fi
   echo '    Custom map server started on port 8000.' >&2
-)
+}
 function get-custom-map-url() {
   MAP_BASE_URL="${MAP_BASE_URL:-http://localhost:8000/}"
   until curl -sIfLo /dev/null "http://localhost:8000/"; do sleep 1; done


### PR DESCRIPTION
I was getting the following error on server startup:
`lgsm_1  | /utils/apply-settings.sh: line 110: syntax error near unexpected token `)'`

After quickly checking the file I realized there should be {} instead of () so I changed it but now the error is:
`lgsm_1  | /utils/apply-settings.sh: line 110: syntax error near unexpected token `}'`
So this does not fix anything but maybe someone can realize what's wrong?
I'm not sure what's the issue... I'm not very experienced with bash scripting.