### PR TITLE
PR to adapt to current docker compose version

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ docker compose up -d
 
 ### Limiting server resources
 
-In the [`docker compose.yml`](docker compose.yml) file, there's two settings you
+In the [`docker-compose.yml`](docker-compose.yml) file, there's two settings you
 can adjust to limit how much CPU and memory the dedicated server is allowed.  By
 default, it is set to dedicated server recommended values for extremly high
 populations:

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Enable port forwarding on your router for the following ports.
 - You have [Git installed][git] and cloned this repository to work with locally.
 
   ```
-  git clone https://github.com/samrocketman/docker compose-lgsm-rust-dedicated-server
+  git clone https://github.com/samrocketman/docker-compose-lgsm-rust-dedicated-server
   ```
 
 - Install [Docker on Linux][docker].  Docker on Windows or Mac would probably

--- a/README.md
+++ b/README.md
@@ -59,13 +59,13 @@ Enable port forwarding on your router for the following ports.
 - You have [Git installed][git] and cloned this repository to work with locally.
 
   ```
-  git clone https://github.com/samrocketman/docker-compose-lgsm-rust-dedicated-server
+  git clone https://github.com/samrocketman/docker compose-lgsm-rust-dedicated-server
   ```
 
 - Install [Docker on Linux][docker].  Docker on Windows or Mac would probably
   work but is entirely untested.  Docker for Mac has known performance issues
   unrelated to Rust.
-- Install [docker-compose][compose].  This typically comes separate from Docker.
+- Install [docker compose][compose].  This typically comes separate from Docker.
 
 # Getting started
 
@@ -73,14 +73,14 @@ If you don't want to customize anything, then start the server.  It will
 generate a 3K map using a random seed which will persist when restarting the
 server.
 
-    docker-compose up -d
+    docker compose up -d
 
 It may take 15 minutes or longer for the server to start the first time
 depending on your internet connection.  This is because it has to download Rust
 among other server setup tasks.  You can monitor the server logs at any time (to
 see progress) with the following command.
 
-    docker-compose logs -f
+    docker compose logs -f
 
 Press `CTRL+C` to exit logs.
 
@@ -88,24 +88,24 @@ Press `CTRL+C` to exit logs.
 
 ### Starting the server
 
-    docker-compose up -d
+    docker compose up -d
 
 It may take at 5 minutes or longer to start depending on your internet
 connection.
 
 See logs with the following command (`CTRL+C` to cancel).
 
-    docker-compose logs -f
+    docker compose logs -f
 
 ### Graceful shutdown
 
-    docker-compose down
+    docker compose down
 
 ### Uninstallation
 
 To completely uninstall and delete all Rust data run the following command.
 
-    docker-compose down -v --rmi all
+    docker compose down -v --rmi all
 
 Remove this Git repository for final cleanup.
 
@@ -157,14 +157,14 @@ this), then you can set the `RUST_RCON_INTERFACE` variable before starting the
 server.
 
 ```bash
-docker-compose down
+docker compose down
 export RUST_RCON_INTERFACE=0.0.0.0
-docker-compose up -d
+docker compose up -d
 ```
 
 ### Limiting server resources
 
-In the [`docker-compose.yml`](docker-compose.yml) file, there's two settings you
+In the [`docker compose.yml`](docker compose.yml) file, there's two settings you
 can adjust to limit how much CPU and memory the dedicated server is allowed.  By
 default, it is set to dedicated server recommended values for extremly high
 populations:
@@ -440,7 +440,7 @@ rm -r changelog.txt Mods observer-island-* Prefabs/
 
 # go back to the root of this repository and start the dedicated server
 cd ..
-docker-compose up -d
+docker compose up -d
 ```
 
 After about 5 minutes you should be able to connect to `localhost:28015`.  If

--- a/admin/backup/create-backup.sh
+++ b/admin/backup/create-backup.sh
@@ -23,7 +23,7 @@ export BACKUP_FILE
 
 [ -d backups ] || mkdir backups
 
-docker-compose exec -Tu linuxgsm lgsm /bin/bash -ex > backups/"$BACKUP_FILE" <<'EOF'
+docker compose exec -Tu linuxgsm lgsm /bin/bash -ex > backups/"$BACKUP_FILE" <<'EOF'
 BACKUP_DIRS=(
   lgsm
   serverfiles/server

--- a/admin/backup/restore-backup.sh
+++ b/admin/backup/restore-backup.sh
@@ -37,10 +37,10 @@ if [ ! "$response" = y -a ! "$response" = Y ]; then
   exit
 fi
 
-server_container_id="$(docker-compose ps -q lgsm)"
+server_container_id="$(docker compose ps -q lgsm)"
 
 if [ -z "${server_container_id}" ]; then
-  echo 'ERROR: Rust server not running... did you "docker-compose up -d"?'
+  echo 'ERROR: Rust server not running... did you "docker compose up -d"?'
   exit 1
 fi
 
@@ -49,10 +49,10 @@ echo "Restoring $1"
 # copy backup file to server
 backup_file="${1##*/}"
 docker cp "$1" "${server_container_id}:/home/linuxgsm/${backup_file}"
-docker-compose exec -T lgsm chown linuxgsm: /home/linuxgsm/"${backup_file}"
+docker compose exec -T lgsm chown linuxgsm: /home/linuxgsm/"${backup_file}"
 
 # restore backup and reboot the server
-docker-compose exec -Tu linuxgsm lgsm bash -ex <<EOF
+docker compose exec -Tu linuxgsm lgsm bash -ex <<EOF
 # kill the uptime monitor before restoring
 if pgrep -f monitor-rust-server.sh &> /dev/null; then
   echo 'Stopping uptime monitor.'
@@ -77,7 +77,7 @@ cat <<'EOT'
 Rebooting the server in 3 seconds...
 Watch restart logs with the following command.
 
-    docker-compose logs -f
+    docker compose logs -f
 
 EOT
 echo ''

--- a/admin/bugfix-oxide-plugins.sh
+++ b/admin/bugfix-oxide-plugins.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker-compose exec -T lgsm /bin/bash -ec 'unix2dos serverfiles/oxide/plugins/*.cs'
+docker compose exec -T lgsm /bin/bash -ec 'unix2dos serverfiles/oxide/plugins/*.cs'

--- a/admin/get-or-update-oxide-plugins.sh
+++ b/admin/get-or-update-oxide-plugins.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker-compose exec -Tu linuxgsm lgsm /utils/get-or-update-plugins.sh
+docker compose exec -Tu linuxgsm lgsm /utils/get-or-update-plugins.sh

--- a/admin/get-rcon-pass.sh
+++ b/admin/get-rcon-pass.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 echo -n 'RCON password: '
-docker-compose exec -T lgsm cat rcon_pass 2> /dev/null || (
+docker compose exec -T lgsm cat rcon_pass 2> /dev/null || (
   # Could not find rcon random password file so falling back to auto detection.
-  docker-compose exec -T lgsm pgrep RustDedicated | \
-  xargs -n1 -I'{}' -- docker-compose exec -T lgsm cat '/proc/{}/cmdline' | \
+  docker compose exec -T lgsm pgrep RustDedicated | \
+  xargs -n1 -I'{}' -- docker compose exec -T lgsm cat '/proc/{}/cmdline' | \
   tr '\0' '\n' | \
   awk '$1 == "+rcon.password" { x="1"; next}; x == "1" {print $0; exit}'
 )

--- a/admin/logs/clean.sh
+++ b/admin/logs/clean.sh
@@ -6,7 +6,7 @@ if [ ! -d .git -a ! -d admin ]; then
 fi
 
 echo 'List of log files:'
-docker-compose exec -T lgsm find log -type f -name '*[0-9]*' -exec du -ch {} + |
+docker compose exec -T lgsm find log -type f -name '*[0-9]*' -exec du -ch {} + |
   awk '
 $2 == "total" {
   total=$1;
@@ -36,12 +36,12 @@ if [ ! "$response" = y -a ! "$response" = Y ]; then
   exit
 fi
 
-docker-compose exec -T lgsm find log -type f -name '*[0-9]*' -exec rm -f {} +
+docker compose exec -T lgsm find log -type f -name '*[0-9]*' -exec rm -f {} +
 
 cat <<'EOF'
 Restart your server to complete cleanup.  Run the following commands.
 
-    docker-compose down
-    docker-compose up -d
+    docker compose down
+    docker compose up -d
 
 EOF

--- a/admin/logs/create-backup.sh
+++ b/admin/logs/create-backup.sh
@@ -22,7 +22,7 @@ BACKUP_FILE="$(date  +%Y-%d-%m-%s)"_lgsm-logs-backup.tgz
 export BACKUP_FILE
 
 [ -d backups ] || mkdir backups
-docker-compose exec -Tu linuxgsm lgsm tar -czv log > backups/"$BACKUP_FILE"
+docker compose exec -Tu linuxgsm lgsm tar -czv log > backups/"$BACKUP_FILE"
 (
 echo
 echo -n 'Created backup file: '

--- a/admin/regenerate-map.sh
+++ b/admin/regenerate-map.sh
@@ -22,12 +22,12 @@ EOF
   fi
 fi
 
-docker-compose exec -T lgsm \
+docker compose exec -T lgsm \
   find serverfiles/server/rustserver/ \
     -maxdepth 1 \
     -type f \( -name '*.map' -o -name '*.sav*' \) \
     -exec rm -f {} +
-docker-compose exec -T lgsm sed -i '/^ *seed=/d' lgsm/config-lgsm/rustserver/rustserver.cfg
-docker-compose down
-docker-compose up -d
-echo 'The server has been rebooted with docker-compose up -d.'
+docker compose exec -T lgsm sed -i '/^ *seed=/d' lgsm/config-lgsm/rustserver/rustserver.cfg
+docker compose down
+docker compose up -d
+echo 'The server has been rebooted with docker compose up -d.'

--- a/admin/shell.sh
+++ b/admin/shell.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker exec -itu "${1:-linuxgsm}" $(docker-compose ps -q lgsm) /bin/bash
+docker exec -itu "${1:-linuxgsm}" $(docker compose ps -q lgsm) /bin/bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,7 @@ services:
       - ./custom-mods/:/custom-plugins/:ro
       - ./custom-maps/:/custom-maps/:rw
       - ./harmony-mods:/home/linuxgsm/serverfiles/HarmonyMods
+      - ./harmony-config:/home/linuxgsm/serverfiles/HarmonyConfig
       - ./utils/:/utils/:ro
       - ./rust-environment.sh:/rust-environment.sh:ro
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2.3'
 volumes:
   lgsm:
 services:

--- a/utils/apply-settings.sh
+++ b/utils/apply-settings.sh
@@ -10,7 +10,7 @@ fi
 export ENABLE_RUST_EAC CUSTOM_MAP_URL MAP_BASE_URL SELF_HOST_CUSTOM_MAP
 export seed salt worldsize maxplayers servername apply_settings_debug_mode
 if [ "${apply_settings_debug_mode:-false}" = true ]; then
-  echo 'docker-compose apply config debug enabled.' >&2
+  echo 'docker compose apply config debug enabled.' >&2
   set -x
 fi
 


### PR DESCRIPTION
`docker-compose` is replaced by `docker compose`
service tag is not required anymore for docker-compose.yaml file.